### PR TITLE
Implement Event System

### DIFF
--- a/CMPUT-250-Project/Assets/Scripts/Events.meta
+++ b/CMPUT-250-Project/Assets/Scripts/Events.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 008a8c13c38fa55dd8db6477abad7408
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CMPUT-250-Project/Assets/Scripts/Events/IntGameEvent.cs
+++ b/CMPUT-250-Project/Assets/Scripts/Events/IntGameEvent.cs
@@ -1,0 +1,4 @@
+﻿using UnityEngine;
+
+[CreateAssetMenu(menuName = "Game Events/IntGameEvent")]
+public class IntGameEvent : GameEvent<int> { }

--- a/CMPUT-250-Project/Assets/Scripts/Events/IntGameEvent.cs.meta
+++ b/CMPUT-250-Project/Assets/Scripts/Events/IntGameEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d607231c6fc4056ea8418d7592799bb4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CMPUT-250-Project/Assets/Scripts/Events/StringGameEvent.cs
+++ b/CMPUT-250-Project/Assets/Scripts/Events/StringGameEvent.cs
@@ -1,0 +1,4 @@
+﻿using UnityEngine;
+
+[CreateAssetMenu(menuName = "Game Events/StringGameEvent")]
+public class StringGameEvent : GameEvent<string> { }

--- a/CMPUT-250-Project/Assets/Scripts/Events/StringGameEvent.cs.meta
+++ b/CMPUT-250-Project/Assets/Scripts/Events/StringGameEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94fe926e2f557eee6b5c275b3f680265
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CMPUT-250-Project/Assets/Scripts/Events/UnitGameEvent.cs
+++ b/CMPUT-250-Project/Assets/Scripts/Events/UnitGameEvent.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Game Events/GameEvent")]
+public class UnitGameEvent : GameEvent<System.ValueTuple>
+{
+    private event Action listeners;
+
+    /// <summary>
+    /// Emit the chosen event
+    /// </summary>
+    public void Emit()
+    {
+        listeners?.Invoke();
+    }
+
+    /// <summary>
+    /// Subscribe to the event
+    /// </summary>
+    public void Subscribe(Action listener)
+    {
+        listeners += listener;
+    }
+
+    /// <summary>
+    /// Unsubscribe from the event
+    /// </summary>
+    public void Unsubscribe(Action listener)
+    {
+        listeners -= listener;
+    }
+}

--- a/CMPUT-250-Project/Assets/Scripts/Events/UnitGameEvent.cs.meta
+++ b/CMPUT-250-Project/Assets/Scripts/Events/UnitGameEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 89a3f34c5355a238da8338370dd533a3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CMPUT-250-Project/Assets/Scripts/GameEvent.cs
+++ b/CMPUT-250-Project/Assets/Scripts/GameEvent.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using UnityEngine;
+
+public class GameEvent<T> : ScriptableObject
+{
+    private event Action<T> listeners;
+
+    /// <summary>
+    /// Emit the chosen event
+    /// </summary>
+    public void Emit(T value)
+    {
+        listeners?.Invoke(value);
+    }
+
+    /// <summary>
+    /// Subscribe to the event
+    /// </summary>
+    public void Subscribe(Action<T> listener)
+    {
+        listeners += listener;
+    }
+
+    /// <summary>
+    /// Unsubscribe from the event
+    /// </summary>
+    public void Unsubscribe(Action<T> listener)
+    {
+        listeners -= listener;
+    }
+}

--- a/CMPUT-250-Project/Assets/Scripts/GameEvent.cs.meta
+++ b/CMPUT-250-Project/Assets/Scripts/GameEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e53713ec99e87f034b60c755ec201102
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Creates an event system for use throughout the game.

+ Adds a ScriptableObject GameEvent<T>
  + Adds UnitGameEvent
  + Adds IntGameEvent
  + Adds StringGameEvent
  + Adding new event types is trivial
  + Events are created in the Assets menu by choosing "Create > Game Event > [Game Event Type]", and represent a single "bus" or "channel" through which that event can be emitted or subscribed to.
+ View the branch `event-system-demo` for a simple demonstration of how the event system works.

The largest advantage that this grants us is decoupling of logic. Yes, logic is still coupled to either an event channel on which to send, or on an event channel on which to recieve data, but this makes
it easy to allow for any number of event emitters or receivers of any given event, and decouples both emitters and receivers from any awareness of the existance of each other. With the ease of creation
of new event channels (literally just make a new Game Event asset), and the ease of use for events, and the ease of switching which event channel is used **in editor**, allows for easy modification and
implementation with few errors.
