### PR TITLE
Convert JSONImporter to static

### DIFF
--- a/CMPUT-250-Project/Assets/Scenes/TechDemoScene.unity
+++ b/CMPUT-250-Project/Assets/Scenes/TechDemoScene.unity
@@ -1909,7 +1909,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1539020980}
   - component: {fileID: 1539020978}
-  - component: {fileID: 1539020979}
   m_Layer: 0
   m_Name: Data
   m_TagString: Untagged
@@ -1927,18 +1926,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3df76cb733ee772448cd1ffa253ae05c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1539020979
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1539020977}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3509ef0976dbc2e45860a66f588b70aa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!4 &1539020980

--- a/CMPUT-250-Project/Assets/Scripts/JSONImporter.cs
+++ b/CMPUT-250-Project/Assets/Scripts/JSONImporter.cs
@@ -17,24 +17,12 @@ public struct UserEntry
 [System.Serializable]
 public struct DirectMessage { }
 
-public class JSONImporter : MonoBehaviour
+public static class JSONImporter
 {
-    // void Start()
-    // {
-    //     // Example using ImportDirectory
-    //     List<UserEntry> users = ImportDirectory<UserEntry>(
-    //         Path.Combine("lang", "en", "days", "day1")
-    //     );
-    //     foreach (UserEntry user in users)
-    //     {
-    //         Debug.Log(JsonUtility.ToJson(user));
-    //     }
-    // }
-
     /// <summary>
     /// Import all .json files in a directory as type T
     /// </summary>
-    public List<T> ImportDirectory<T>(string dir_path)
+    public static List<T> ImportDirectory<T>(string dir_path)
     {
         string path = Path.Combine(Application.streamingAssetsPath, dir_path);
 
@@ -61,7 +49,7 @@ public class JSONImporter : MonoBehaviour
         // }
     }
 
-    private T ImportFile<T>(string filename)
+    private static T ImportFile<T>(string filename)
     {
         // try
         // {
@@ -75,7 +63,7 @@ public class JSONImporter : MonoBehaviour
         // }
     }
 
-    private string ReadFileToString(string path)
+    private static string ReadFileToString(string path)
     {
         // try
         // {

--- a/CMPUT-250-Project/Assets/Scripts/UserManager.cs
+++ b/CMPUT-250-Project/Assets/Scripts/UserManager.cs
@@ -5,15 +5,13 @@ using UnityEngine;
 
 public class UserManager : MonoBehaviour
 {
-    private JSONImporter jsonImporter;
     private int currentUserIndex = 0;
     private List<UserEntry> users;
 
     void Awake()
     {
         // load users
-        jsonImporter = GetComponent<JSONImporter>();
-        users = jsonImporter.ImportDirectory<UserEntry>(Path.Combine("lang", "en", "days", "day1"));
+        users = JSONImporter.ImportDirectory<UserEntry>(Path.Combine("lang", "en", "days", "day1"));
 
         // set first user
         if (users == null || users.Count == 0)


### PR DESCRIPTION
Converts the JSONImporter to be a `public static class` composed entirely of `static` methods.
This allows access to JSONImporter from anywhere, without requiring a GameObject or reference (similar to a singleton).

+ Updates JSONImporter to `static`
+ Fixes UserManager as a result of the aforementioned update
