### PR TITLE
Day Management and Event Overhaul

### DIFF
--- a/CMPUT-250-Project/Assets/Days.meta
+++ b/CMPUT-250-Project/Assets/Days.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 197e3ccb3dd002282bcacb9f3cc313c2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CMPUT-250-Project/Assets/Days/Day One.asset
+++ b/CMPUT-250-Project/Assets/Days/Day One.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8ae3ad5ed19f8e064af2e3cb234c606e, type: 3}
+  m_Name: Day One
+  m_EditorClassIdentifier: 
+  Directory: day1
+  Date: 2025-10-03
+  Users:
+  - filename: user1
+    before: []
+    after: []
+  - filename: user2
+    before: []
+    after: []

--- a/CMPUT-250-Project/Assets/Days/Day One.asset.meta
+++ b/CMPUT-250-Project/Assets/Days/Day One.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 360076ef013db9f3fa77780f7a9851cb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CMPUT-250-Project/Assets/Events.meta
+++ b/CMPUT-250-Project/Assets/Events.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 09aab3cc76e330ced8f5947e661fe08f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CMPUT-250-Project/Assets/Events/RequestUserInfo.asset
+++ b/CMPUT-250-Project/Assets/Events/RequestUserInfo.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 89a3f34c5355a238da8338370dd533a3, type: 3}
+  m_Name: RequestUserInfo
+  m_EditorClassIdentifier: 

--- a/CMPUT-250-Project/Assets/Events/RequestUserInfo.asset.meta
+++ b/CMPUT-250-Project/Assets/Events/RequestUserInfo.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bd767a99f22ae800b90886e07da843ce
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CMPUT-250-Project/Assets/Events/ResolveAppeal.asset
+++ b/CMPUT-250-Project/Assets/Events/ResolveAppeal.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b8653079f27210b1a549926ba710dbf, type: 3}
+  m_Name: ResolveAppeal
+  m_EditorClassIdentifier: 

--- a/CMPUT-250-Project/Assets/Events/ResolveAppeal.asset.meta
+++ b/CMPUT-250-Project/Assets/Events/ResolveAppeal.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4c381b5a82e316b71a52ad513c65bbb5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CMPUT-250-Project/Assets/Events/UserLoaded.asset
+++ b/CMPUT-250-Project/Assets/Events/UserLoaded.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a13a3ecb4f3bdfa2addefbfa7714e57, type: 3}
+  m_Name: UserLoaded
+  m_EditorClassIdentifier: 

--- a/CMPUT-250-Project/Assets/Events/UserLoaded.asset.meta
+++ b/CMPUT-250-Project/Assets/Events/UserLoaded.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2e23c26185f87442795df3f94db57909
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CMPUT-250-Project/Assets/Scenes/TechDemoScene.unity
+++ b/CMPUT-250-Project/Assets/Scenes/TechDemoScene.unity
@@ -1763,8 +1763,10 @@ MonoBehaviour:
   AppealText: {fileID: 558936790}
   ChatLogText: {fileID: 1146844095}
   ChatScroll: {fileID: 0}
+  delayTime: 1
   RefreshUserInfo: {fileID: 11400000, guid: 2e23c26185f87442795df3f94db57909, type: 2}
   ResolveAppeal: {fileID: 11400000, guid: 4c381b5a82e316b71a52ad513c65bbb5, type: 2}
+  RequestUser: {fileID: 11400000, guid: bd767a99f22ae800b90886e07da843ce, type: 2}
 --- !u!1 &1457516533
 GameObject:
   m_ObjectHideFlags: 0
@@ -1940,6 +1942,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Day: {fileID: 11400000, guid: 360076ef013db9f3fa77780f7a9851cb, type: 2}
   ResolveAppeal: {fileID: 11400000, guid: 4c381b5a82e316b71a52ad513c65bbb5, type: 2}
+  UserInfoRequest: {fileID: 11400000, guid: bd767a99f22ae800b90886e07da843ce, type: 2}
   UserLoaded: {fileID: 11400000, guid: 2e23c26185f87442795df3f94db57909, type: 2}
   AfterAppeal: {fileID: 0}
 --- !u!4 &1539020980

--- a/CMPUT-250-Project/Assets/Scenes/TechDemoScene.unity
+++ b/CMPUT-250-Project/Assets/Scenes/TechDemoScene.unity
@@ -1093,7 +1093,18 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 676759490}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1239063810}
+        m_MethodName: OnDecision
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &676759490
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1746,15 +1757,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 388d279957e6a8f45876113a138c4026, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  userManager: {fileID: 1539020978}
-  nameText: {fileID: 1651128188}
-  dateText: {fileID: 1852667167}
-  bioText: {fileID: 1907957896}
-  appealText: {fileID: 558936790}
-  chatLogText: {fileID: 1146844095}
-  chatScroll: {fileID: 0}
-  approveButton: {fileID: 1744924064}
-  ignoreButton: {fileID: 676759489}
+  NameText: {fileID: 1651128188}
+  DateText: {fileID: 1852667167}
+  BioText: {fileID: 1907957896}
+  AppealText: {fileID: 558936790}
+  ChatLogText: {fileID: 1146844095}
+  ChatScroll: {fileID: 0}
+  RefreshUserInfo: {fileID: 11400000, guid: 2e23c26185f87442795df3f94db57909, type: 2}
+  ResolveAppeal: {fileID: 11400000, guid: 4c381b5a82e316b71a52ad513c65bbb5, type: 2}
 --- !u!1 &1457516533
 GameObject:
   m_ObjectHideFlags: 0
@@ -1928,6 +1938,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3df76cb733ee772448cd1ffa253ae05c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Day: {fileID: 11400000, guid: 360076ef013db9f3fa77780f7a9851cb, type: 2}
+  ResolveAppeal: {fileID: 11400000, guid: 4c381b5a82e316b71a52ad513c65bbb5, type: 2}
+  UserLoaded: {fileID: 11400000, guid: 2e23c26185f87442795df3f94db57909, type: 2}
+  AfterAppeal: {fileID: 0}
 --- !u!4 &1539020980
 Transform:
   m_ObjectHideFlags: 0
@@ -2101,7 +2115,18 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1744924065}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1239063810}
+        m_MethodName: OnDecision
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
 --- !u!114 &1744924065
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/CMPUT-250-Project/Assets/Scripts/AppealPanelController.cs
+++ b/CMPUT-250-Project/Assets/Scripts/AppealPanelController.cs
@@ -25,6 +25,7 @@ public class AppealPanelController : Subscriber
 
     [Header("Events")]
     public BoolGameEvent ResolveAppeal;
+    public UnitGameEvent RequestUser;
 
     protected override void Subscribe()
     {
@@ -34,6 +35,7 @@ public class AppealPanelController : Subscriber
     void OnEnable()
     {
         RefreshUI(null);
+        RequestUser?.Emit();
         canUpdate = true;
     }
 
@@ -88,22 +90,16 @@ public class AppealPanelController : Subscriber
         {
             if (canUpdate == true)
             {
-                if (userManager.MoveToNextUser())
-                {
-                    RefreshUI();
-                    StartCoroutine(DelayAction(delayTime));
-                }
+                OnDecision(false);
+                StartCoroutine(DelayAction(delayTime));
             }
         }
         if (Input.GetKey(KeyCode.D))
         {
             if (canUpdate == true)
             {
-                if (userManager.MoveToNextUser())
-                {
-                    RefreshUI();
-                    StartCoroutine(DelayAction(delayTime));
-                }
+                OnDecision(false);
+                StartCoroutine(DelayAction(delayTime));
             }
         }
     }

--- a/CMPUT-250-Project/Assets/Scripts/DayDefinition.cs
+++ b/CMPUT-250-Project/Assets/Scripts/DayDefinition.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+[Serializable]
+public struct UserDefinition
+{
+    public string filename;
+
+    [Header("Events")]
+    public UnitGameEvent[] before;
+    public BoolGameEvent[] after;
+}
+
+[CreateAssetMenu(menuName = "Day Definition")]
+public class DayDefinition : ScriptableObject
+{
+    public string Directory;
+    public string Date;
+    public List<UserDefinition> Users;
+
+    public DayDefinition(string DirectoryIn)
+    {
+        Directory = DirectoryIn;
+        Users = new List<UserDefinition>();
+        Date = "";
+    }
+
+    public DayDefinition(string DirectoryIn, string DateIn)
+    {
+        Directory = DirectoryIn;
+        Users = new List<UserDefinition>();
+        Date = DateIn;
+    }
+
+    public DayDefinition(string DirectoryIn, string DateIn, List<UserDefinition> UserIn)
+    {
+        Directory = DirectoryIn;
+        Users = UserIn;
+        Date = DateIn;
+    }
+}

--- a/CMPUT-250-Project/Assets/Scripts/DayDefinition.cs.meta
+++ b/CMPUT-250-Project/Assets/Scripts/DayDefinition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8ae3ad5ed19f8e064af2e3cb234c606e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CMPUT-250-Project/Assets/Scripts/Events/BoolGameEvent.cs
+++ b/CMPUT-250-Project/Assets/Scripts/Events/BoolGameEvent.cs
@@ -1,0 +1,4 @@
+﻿using UnityEngine;
+
+[CreateAssetMenu(menuName = "Game Events/BoolGameEvent")]
+public class BoolGameEvent : GameEvent<bool> { }

--- a/CMPUT-250-Project/Assets/Scripts/Events/BoolGameEvent.cs.meta
+++ b/CMPUT-250-Project/Assets/Scripts/Events/BoolGameEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b8653079f27210b1a549926ba710dbf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CMPUT-250-Project/Assets/Scripts/Events/UserEntryGameEvent.cs
+++ b/CMPUT-250-Project/Assets/Scripts/Events/UserEntryGameEvent.cs
@@ -1,0 +1,4 @@
+﻿using UnityEngine;
+
+[CreateAssetMenu(menuName = "Game Events/UserEntryGameEvent")]
+public class UserEntryGameEvent : GameEvent<UserEntry> { }

--- a/CMPUT-250-Project/Assets/Scripts/Events/UserEntryGameEvent.cs.meta
+++ b/CMPUT-250-Project/Assets/Scripts/Events/UserEntryGameEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a13a3ecb4f3bdfa2addefbfa7714e57
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CMPUT-250-Project/Assets/Scripts/JSONImporter.cs
+++ b/CMPUT-250-Project/Assets/Scripts/JSONImporter.cs
@@ -20,8 +20,6 @@ public struct DirectMessage { }
 
 public static class JSONImporter
 {
-    private static Regex regex = new Regex(@"([^\/\\]+)(?:\.json)$");
-
     /// <summary>
     /// Import all .json files in a directory as type T
     /// </summary>
@@ -38,7 +36,7 @@ public static class JSONImporter
         {
             if (filename.EndsWith(".json"))
             {
-                string simple_name = regex.Match(filename).Groups[1].Value;
+                string simple_name = Path.GetFileNameWithoutExtension(filename);
                 items.Add(simple_name, ImportFile<T>(filename));
             }
         }

--- a/CMPUT-250-Project/Assets/Scripts/JSONImporter.cs
+++ b/CMPUT-250-Project/Assets/Scripts/JSONImporter.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 using UnityEngine;
 
 [System.Serializable]
@@ -19,27 +20,26 @@ public struct DirectMessage { }
 
 public static class JSONImporter
 {
+    private static Regex regex = new Regex(@"([^\/\\]+)(?:\.json)$");
+
     /// <summary>
     /// Import all .json files in a directory as type T
     /// </summary>
-    public static List<T> ImportDirectory<T>(string dir_path)
+    public static Dictionary<string, T> ImportDirectory<T>(string dir_path)
     {
         string path = Path.Combine(Application.streamingAssetsPath, dir_path);
 
         // All try-catches are commented for now to imply fallability, even if I haven't taken the time to implement correct error handling
         // try
         // {
-        List<T> items = new List<T>();
+        Dictionary<string, T> items = new Dictionary<string, T>();
 
-        // Sort the filenames
-        List<string> files = new List<string>(Directory.EnumerateFiles(path));
-        files.Sort();
-
-        foreach (string filename in files)
+        foreach (string filename in Directory.EnumerateFiles(path))
         {
             if (filename.EndsWith(".json"))
             {
-                items.Add(ImportFile<T>(filename));
+                string simple_name = regex.Match(filename).Groups[1].Value;
+                items.Add(simple_name, ImportFile<T>(filename));
             }
         }
         return items;

--- a/CMPUT-250-Project/Assets/Scripts/Subscriber.cs
+++ b/CMPUT-250-Project/Assets/Scripts/Subscriber.cs
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+
+public abstract class Subscriber : MonoBehaviour
+{
+    protected virtual void Awake()
+    {
+        SubscriptionManager.Subscribe += Subscribe;
+        SubscriptionManager.AfterSubscribe += AfterSubscribe;
+    }
+
+    protected virtual void Subscribe() { }
+
+    protected virtual void AfterSubscribe() { }
+}

--- a/CMPUT-250-Project/Assets/Scripts/Subscriber.cs.meta
+++ b/CMPUT-250-Project/Assets/Scripts/Subscriber.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6592f65169c5f7eb488fd5775e819e84
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CMPUT-250-Project/Assets/Scripts/SubscriptionManager.cs
+++ b/CMPUT-250-Project/Assets/Scripts/SubscriptionManager.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using UnityEngine;
+
+public static class SubscriptionManager
+{
+    public static Action Subscribe;
+    public static Action AfterSubscribe;
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    static void Awake()
+    {
+        Subscribe?.Invoke();
+        AfterSubscribe?.Invoke();
+    }
+}

--- a/CMPUT-250-Project/Assets/Scripts/SubscriptionManager.cs.meta
+++ b/CMPUT-250-Project/Assets/Scripts/SubscriptionManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 63e30403124cb83d4954514d48e01ede
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 1000
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CMPUT-250-Project/Assets/Scripts/UserManager.cs
+++ b/CMPUT-250-Project/Assets/Scripts/UserManager.cs
@@ -12,6 +12,7 @@ public class UserManager : Subscriber
 
     [Header("Event Listeners")]
     public BoolGameEvent ResolveAppeal;
+    public UnitGameEvent UserInfoRequest;
 
     [Header("Events")]
     public UserEntryGameEvent UserLoaded;
@@ -22,6 +23,7 @@ public class UserManager : Subscriber
     protected override void Subscribe()
     {
         ResolveAppeal?.Subscribe(OnResolveAppeal);
+        UserInfoRequest?.Subscribe(OnUserInfoRequest);
     }
 
     protected override void AfterSubscribe()
@@ -107,6 +109,15 @@ public class UserManager : Subscriber
         foreach (UnitGameEvent before in Day.Users[currentUserIndex].before)
         {
             before.Emit();
+        }
+    }
+
+    private void OnUserInfoRequest()
+    {
+        UserEntry? user = GetCurrentUser();
+        if (user != null)
+        {
+            UserLoaded.Emit(user.Value);
         }
     }
 

--- a/CMPUT-250-Project/Assets/Scripts/UserManager.cs
+++ b/CMPUT-250-Project/Assets/Scripts/UserManager.cs
@@ -3,45 +3,48 @@ using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
 
-public class UserManager : MonoBehaviour
+public class UserManager : Subscriber
 {
+    public DayDefinition Day;
+
     private int currentUserIndex = 0;
-    private List<UserEntry> users;
+    private Dictionary<string, UserEntry> users;
 
-    void Awake()
+    [Header("Event Listeners")]
+    public BoolGameEvent ResolveAppeal;
+
+    [Header("Events")]
+    public UserEntryGameEvent UserLoaded;
+
+    // `true` implies player chose correctly, `false` implies player chose incorrectly
+    public BoolGameEvent AfterAppeal;
+
+    protected override void Subscribe()
     {
+        ResolveAppeal?.Subscribe(OnResolveAppeal);
+    }
+
+    protected override void AfterSubscribe()
+    {
+        if (Day == null)
+        {
+            Day = new DayDefinition("daynull");
+        }
+
         // load users
-        users = JSONImporter.ImportDirectory<UserEntry>(Path.Combine("lang", "en", "days", "day1"));
+        users = JSONImporter.ImportDirectory<UserEntry>(
+            Path.Combine("lang", "en", "days", Day.Directory)
+        );
 
-        // set first user
-        if (users == null || users.Count == 0)
-        {
-            currentUserIndex = -1; // no users loaded
-        }
-        else
-        {
-            currentUserIndex = 0; // first user by default
-        }
+        currentUserIndex = -1;
+        MoveToNextUser();
     }
 
-    void Update()
-    {
-        // what i commented out is an example usage of the methods in usermanager
-
-        // // testing
-        // if(Input.GetKey(KeyCode.W) || Input.GetKey(KeyCode.UpArrow)){
-        //     MoveToNextUser();
-        // }
-        // if(Input.GetKey(KeyCode.A) || Input.GetKey(KeyCode.LeftArrow)){
-        //     Debug.Log(GetCurrentUserName());
-        // }
-    }
-
-    public UserEntry? GetCurrentUser()
+    private UserEntry? GetCurrentUser()
     {
         if (users != null && currentUserIndex >= 0 && currentUserIndex < users.Count)
         {
-            return users[currentUserIndex];
+            return users[Day.Users[currentUserIndex].filename];
         }
 
         // Might be worth making an "error" user that just displays a bunch of shit to use when things go wrong
@@ -51,7 +54,7 @@ public class UserManager : MonoBehaviour
     }
 
     // moves to next user index
-    public bool MoveToNextUser()
+    private bool MoveToNextUser()
     {
         // if we somehow get here with no users
         if (users == null || users.Count == 0)
@@ -66,6 +69,8 @@ public class UserManager : MonoBehaviour
         {
             currentUserIndex = 0;
         }
+
+        UserLoaded?.Emit(users[Day.Users[currentUserIndex].filename]);
 
         // return true if successful
         return true;
@@ -83,123 +88,25 @@ public class UserManager : MonoBehaviour
         return false;
     }
 
-    // get users username
-    public string GetCurrentUserName()
+    private void OnResolveAppeal(bool decision)
     {
-        var user = GetCurrentUser();
-
+        UserEntry? user = GetCurrentUser();
         if (user != null)
         {
-            return user.Value.name;
-        }
-        else
-        {
-            return null;
-        }
-    }
+            bool success = decision == user.Value.should_approve;
 
-    // get the date for your messages
-    public string GetCurrentUserDate()
-    {
-        var user = GetCurrentUser();
-
-        if (user != null)
-        {
-            return user.Value.date;
+            AfterAppeal?.Emit(success);
+            foreach (BoolGameEvent after in Day.Users[currentUserIndex].after)
+            {
+                after.Emit(success);
+            }
         }
-        else
-        {
-            return null;
-        }
-    }
 
-    // get your users bio
-    public string GetCurrentUserBio()
-    {
-        var user = GetCurrentUser();
+        MoveToNextUser();
 
-        if (user != null)
+        foreach (UnitGameEvent before in Day.Users[currentUserIndex].before)
         {
-            return user.Value.bio;
-        }
-        else
-        {
-            return null;
-        }
-    }
-
-    // get the index related to what the current image should be
-    public int? GetCurrentUserImg()
-    {
-        var user = GetCurrentUser();
-
-        if (user != null)
-        {
-            return user.Value.image_index;
-        }
-        else
-        {
-            return null;
-        }
-    }
-
-    // get the appeal message
-    public string GetCurrentUserAppeal()
-    {
-        var user = GetCurrentUser();
-
-        if (user != null)
-        {
-            return user.Value.appeal_message;
-        }
-        else
-        {
-            return null;
-        }
-    }
-
-    // get the approval bool
-    public bool? GetCurrentUserApproval()
-    {
-        var user = GetCurrentUser();
-
-        if (user != null)
-        {
-            return user.Value.should_approve;
-        }
-        else
-        {
-            return null;
-        }
-    }
-
-    // get a specific message
-    public string GetCurrentUserMessage(int index)
-    {
-        var user = GetCurrentUser();
-
-        if (user != null)
-        {
-            return user.Value.messages[index];
-        }
-        else
-        {
-            return null;
-        }
-    }
-
-    // get all messages
-    public string[] GetCurrentUserMessagesAll()
-    {
-        var user = GetCurrentUser();
-
-        if (user != null)
-        {
-            return user.Value.messages;
-        }
-        else
-        {
-            return null;
+            before.Emit();
         }
     }
 


### PR DESCRIPTION
# Commit Message

+ Days are now managed by the UserManager
+ Added SubscriptionManager and Subscriber classes
+ Changed UserManager and AppealPanelController to inherit from Subcriber
+ Added ResolveAppeal and UserLoaded classes
+ Updated JSONImporter to read files into HashMap
+ Added DayDefinition ScriptableObject to CreateAssetMenu
+ Created BoolGameEvent and UserGameEvent datatypes
+ Added 'Day One' Definition

# Notes

Frankly, this should have been split up into two separate PRs, across multiple commits, but I just kept on doing "one more thing", so now we're here I guess.
